### PR TITLE
Fix typo in tiffredef filename

### DIFF
--- a/sources/tiff/tiffio.h
+++ b/sources/tiff/tiffio.h
@@ -32,7 +32,7 @@
  */
 #include "tiff.h"
 #include "tiffconf.h" 
-#include "tiffredeff.h" 
+#include "tiffredef.h"
 
 /*
  * TIFF is defined as an incomplete type to hide the


### PR DESCRIPTION
I am compiling this library into a project I am building (will release soon, and respect the *GPL licenses, of course).

I noticed this typo though, so I wanted to push this to upstream